### PR TITLE
feat: add google signin controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
+    "dev:dry": "cross-env NODE_ENV=develop nodemon --watch 'src/**/*.ts' --exec 'ts-node' -r tsconfig-paths/register --files src/index.ts",
     "dev": "npx prisma db pull && npx prisma generate && cross-env NODE_ENV=develop nodemon --watch 'src/**/*.ts' --exec 'ts-node' -r tsconfig-paths/register --files src/index.ts",
     "start": "cross-env NODE_ENV=prod ts-node --transpileOnly -r tsconfig-paths/register ./src/index.ts",
     "db": "npx prisma db push && npx prisma db pull && npx prisma generate"
@@ -11,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/jsonwebtoken": "^8.5.5",
@@ -38,12 +40,14 @@
     "axios": "^0.25.0",
     "bcrypt": "^5.0.1",
     "bwip-js": "^3.0.4",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
     "crypto-js": "^4.1.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
+    "google-auth-library": "^8.1.1",
     "helmet": "^5.0.1",
     "joi": "^17.4.2",
     "joi-to-swagger": "^6.0.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express, { NextFunction, Request, Response } from "express";
 import bearerToken from "express-bearer-token";
+import cookieParser from "cookie-parser";
 import morgan from "morgan";
 import helmet from "helmet";
 import cors from "cors";
@@ -26,6 +27,7 @@ class App {
     this.app.use(errorProcessingMiddleware);
   }
   private initializeMiddlewares() {
+    this.app.use(cookieParser());
     this.app.use(helmet());
     this.app.use(cors());
     this.app.use(express.json()); // for parsing application/json

--- a/src/interfaces/dimi-api.ts
+++ b/src/interfaces/dimi-api.ts
@@ -1,12 +1,12 @@
 import { DimiUserType, Gender } from "@src/types";
 
-export interface LoginInfo {
-  username: string;
-  password: string;
-  pin: string;
-  deviceUid: string;
-  bioKey: string;
-}
+type Body<T extends string> = Record<T, string>;
+
+type LoginInfoBase = Body<"pin" | "deviceUid" | "bioKey">;
+
+export type LoginInfo = LoginInfoBase & Body<"username" | "password">;
+export type GoogleLoginIngo = LoginInfoBase &
+  Body<"credential" | "g_csrf_token">;
 
 export interface UserIdentity {
   id: number;

--- a/src/services/auth/controllers.ts
+++ b/src/services/auth/controllers.ts
@@ -11,7 +11,7 @@ import { LoginInfo, UserIdentity } from "@src/interfaces";
 import { Prisma, User } from "@prisma/client";
 import bcrypt from "bcrypt";
 
-const createTokensFromUser = async (user: Partial<User>) => {
+export const createTokensFromUser = async (user: Partial<User>) => {
   const { systemId } = user;
   return {
     accessToken: await issueToken({ systemId }, false),

--- a/src/services/auth/google-auth.ts
+++ b/src/services/auth/google-auth.ts
@@ -1,0 +1,130 @@
+import bcrypt from "bcrypt";
+import { prisma } from "@src/resources";
+import { HttpException } from "@src/exceptions";
+import { createTokensFromUser } from "./controllers";
+import { OAuth2Client, TokenPayload } from "google-auth-library";
+
+import type { Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+import type { GoogleLoginIngo } from "@src/interfaces";
+
+const googleOAuth2Client: OAuth2Client = new OAuth2Client();
+
+const registerOrLoginByGoogle = async (payload: TokenPayload) => {
+  const userid = payload.aud;
+  const queriedUser = await prisma.user.findUnique({
+    where: { systemId: userid },
+    select: {
+      systemId: true,
+      accountName: true,
+      isDisabled: true,
+      isTeacher: true,
+      name: true,
+      paymentMethods: true,
+      profileImage: true,
+      createdAt: true,
+      updatedAt: true,
+      paymentPin: true,
+      deviceUid: true,
+    },
+  });
+
+  if (queriedUser) {
+    if (queriedUser.paymentPin || queriedUser.deviceUid) {
+      return { user: queriedUser, isFirstVisit: false };
+    }
+    // PIN, device 미등록 사용자
+    return { user: queriedUser, isFirstVisit: true };
+  }
+
+  /**
+   * @todo how to define accountName? (now it is email)
+   *
+   * @note In order to use email, name and picture,
+   *       the request scope should include the string "profile"
+   *       In this, I assumed that the request scope is "profile email"
+   */
+  const mappedUser: Prisma.UserCreateInput = {
+    systemId: userid,
+    accountName: payload.email,
+    name: payload.name,
+    profileImage: payload.picture,
+  };
+
+  const user = await prisma.user.create({
+    data: mappedUser,
+  });
+
+  return { user, isFirstVisit: true };
+};
+
+export const googleIdentifyUser = async (req: Request, res: Response) => {
+  const body: GoogleLoginIngo = req.body;
+
+  try {
+    // I temporarily disabled this because of testing
+    /* // verify csrf token
+    const csrfTokenCookie: string | undefined = req.cookies.g_csrf_token;
+    if (!csrfTokenCookie) {
+      throw new HttpException(400, "CSRF 토큰이 쿠키에 없습니다.");
+    }
+    const csrfTokenBody: string | undefined = req.body.g_csrf_token;
+    if (!csrfTokenBody) {
+      throw new HttpException(400, "CSRF 토큰이 전달되지 않았습니다.");
+    }
+    if (csrfTokenCookie !== csrfTokenBody) {
+      throw new HttpException(400, "이중 제출 쿠키 인증에 실패했습니다.");
+    } */
+
+    /**
+     * @todo check sub value(in google client id) to verify right client request
+     */
+
+    const payload = (
+      await googleOAuth2Client.verifyIdToken({ idToken: body.credential })
+    ).getPayload();
+
+    const { user, isFirstVisit } = await registerOrLoginByGoogle(payload);
+
+    // code down below is just a copy of main controller
+    // but im gon fix this later
+    if (isFirstVisit) {
+      if (body.pin && body.deviceUid) {
+        await prisma.user.update({
+          where: { systemId: user.systemId },
+          data: {
+            paymentPin: bcrypt.hashSync(body.pin, 10),
+            deviceUid: body.deviceUid,
+            bioKey: bcrypt.hashSync(body.bioKey, 10),
+          },
+        });
+
+        return res.json({ ...(await createTokensFromUser(user)) });
+      } else {
+        throw new HttpException(400, "신규 등록이 필요합니다.");
+      }
+    }
+
+    if (bcrypt.compareSync(body.pin, user.paymentPin)) {
+      if (body.deviceUid !== user.deviceUid) {
+        // deviceUid 재설정
+        await prisma.user.update({
+          where: { systemId: user.systemId },
+          data: {
+            deviceUid: body.deviceUid,
+            bioKey: bcrypt.hashSync(body.bioKey, 10),
+          },
+        });
+
+        return res.json({ ...(await createTokensFromUser(user)) });
+      } else {
+        // 등록된 기기에서 재로그인하는 경우
+        return res.json({ ...(await createTokensFromUser(user)) });
+      }
+    }
+
+    throw new HttpException(400, "올바르지 않은 PIN입니다.");
+  } catch (e) {
+    throw new HttpException(e.status, e.message);
+  }
+};

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,6 +1,7 @@
 import Joi from "joi";
 import * as controllers from "./controllers";
 import * as posControllers from "./pos-controllers";
+import * as GoogleAuthController from "./google-auth";
 import { createService } from "../index";
 
 export default createService({
@@ -17,6 +18,20 @@ export default createService({
       validateSchema: {
         username: Joi.string().required(),
         password: Joi.string().required(),
+        pin: Joi.string().required(),
+        bioKey: Joi.string().required(),
+        deviceUid: Joi.string().required(),
+      },
+    },
+    {
+      method: "post",
+      path: "/login/google",
+      handler: GoogleAuthController.googleIdentifyUser,
+      needAuth: false,
+      description: "Google OAuth로 Access Token과 Refresh Token을 발급합니다.",
+      validateSchema: {
+        credential: Joi.string().required(),
+        g_csrf_token: Joi.string().required(),
         pin: Joi.string().required(),
         bioKey: Joi.string().required(),
         deviceUid: Joi.string().required(),


### PR DESCRIPTION
몇가지 체크해야할 부분이 있어 우선 큰 흐름을 만들어보았습니다.

## flow
현재 흐름은

redirect at client side --> redirect to api after sign in with google --> sign in or sign up and get back to the client

이지만, 생각해보니 리디렉트 경로를 설정하기 까다로울것 같아 아래 플로우로 변경할것입니다.

go to `auth/login/google` --> immediately redirect to google login page --> create user or login
 

## to check
-  [ ] 기존 로그인 요청은  `pin`, `bioKey`, `deviceUid` 를 한번에 받았는데, 구글 로그인 과정에선 구글을 통해 사용자 정보를 먼저 받고, 회원가입이 필요한 경우에 추가 정보를 요청해야 할 것 같습니다.
-  [ ] 위 과정을 따른다면, 사용자 추가 과정에서 `accountName`를 어떤 값으로 설정하는것이 좋을까요?
-  [ ] google client id도 필요합니다.